### PR TITLE
4.7.12.1 no bash

### DIFF
--- a/alpine-conda/Dockerfile
+++ b/alpine-conda/Dockerfile
@@ -1,7 +1,7 @@
 FROM frolvlad/alpine-glibc:alpine-3.9_glibc-2.29
 LABEL MAINTAINER="Jim Crist"
 
-ENV CONDA_VERSION 4.7.12
+ENV CONDA_VERSION 4.7.12.1
 ENV CONDA_MD5 0dba759b8ecfc8948f626fa18785e3d8
 
 # Tell Python not to recreate the bytecode files. Since this is a docker image,

--- a/alpine-conda/Dockerfile
+++ b/alpine-conda/Dockerfile
@@ -20,7 +20,7 @@ ENV PYTHONDONTWRITEBYTECODE=true
 # - Cleanup conda files
 # - Uninstall miniconda install dependencies
 # Allow chown into opt so that the user can write/ create additional installations
-RUN apk add --no-cache wget bzip2 \
+RUN apk add --no-cache wget bzip2 bash findutils \
     && addgroup -S anaconda \
     && adduser -D -u 10151 anaconda -G anaconda \
     && wget --quiet https://repo.continuum.io/miniconda/Miniconda3-$CONDA_VERSION-Linux-x86_64.sh \
@@ -40,9 +40,6 @@ RUN apk add --no-cache wget bzip2 \
     && /opt/conda/bin/conda clean -afy \
     && chown -R anaconda:anaconda /opt/ \
     && apk del wget bzip2
-
-USER anaconda:anaconda
-WORKDIR /home/anaconda/
 
 COPY start.sh /usr/local/bin/
 

--- a/alpine-conda/Dockerfile
+++ b/alpine-conda/Dockerfile
@@ -1,8 +1,8 @@
 FROM frolvlad/alpine-glibc:alpine-3.9_glibc-2.29
 LABEL MAINTAINER="Jim Crist"
 
-ENV CONDA_VERSION 4.6.14
-ENV CONDA_MD5 718259965f234088d785cad1fbd7de03
+ENV CONDA_VERSION 4.7.12
+ENV CONDA_MD5 0dba759b8ecfc8948f626fa18785e3d8
 
 # Tell Python not to recreate the bytecode files. Since this is a docker image,
 # these will be recreated every time, writing them just uses unnecessary disk
@@ -14,7 +14,6 @@ ENV PYTHONDONTWRITEBYTECODE=true
 # - Install miniconda install dependencies
 # - Download miniconda and check the md5sum
 # - Install miniconda
-# - Downgrade and pin conda to 4.6.8 (can remove once 4.7 is released)
 # - Install tini
 # - Remove all conda managed static libraries
 # - Remove all conda managed *.pyc files
@@ -32,8 +31,8 @@ RUN apk add --no-cache wget bzip2 \
     && ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh \
     && echo ". /opt/conda/etc/profile.d/conda.sh" >> /home/anaconda/.profile \
     && echo "conda activate base" >> /home/anaconda/.profile \
-    && /opt/conda/bin/conda install conda==4.6.8 \
-    && echo "conda ==4.6.8" >> /opt/conda/conda-meta/pinned \
+    && /opt/conda/bin/conda install conda==$CONDA_VERSION \
+    && echo "conda==$CONDA_VERSION" >> /opt/conda/conda-meta/pinned \
     && /opt/conda/bin/conda install --freeze-installed tini -y \
     && find /opt/conda/ -follow -type f -name '*.a' -delete \
     && find /opt/conda/ -follow -type f -name '*.pyc' -delete \

--- a/alpine-conda/Dockerfile
+++ b/alpine-conda/Dockerfile
@@ -1,8 +1,10 @@
 FROM frolvlad/alpine-glibc:alpine-3.9_glibc-2.29
 LABEL MAINTAINER="Jim Crist"
 
-ENV CONDA_VERSION 4.7.12.1
-ENV CONDA_MD5 0dba759b8ecfc8948f626fa18785e3d8
+ENV CONDA_VERSION 4.7.12
+ENV CONDA_PATCH_VERSION 4.7.12.1
+ENV CONDA_FILENAME Miniconda3-$CONDA_PATCH_VERSION-Linux-x86_64.sh
+ENV CONDA_FILENAME_MD5 81c773ff87af5cfac79ab862942ab6b3
 
 # Tell Python not to recreate the bytecode files. Since this is a docker image,
 # these will be recreated every time, writing them just uses unnecessary disk
@@ -20,13 +22,14 @@ ENV PYTHONDONTWRITEBYTECODE=true
 # - Cleanup conda files
 # - Uninstall miniconda install dependencies
 # Allow chown into opt so that the user can write/ create additional installations
+
 RUN apk add --no-cache wget bzip2 bash findutils \
     && addgroup -S anaconda \
     && adduser -D -u 10151 anaconda -G anaconda \
-    && wget --quiet https://repo.continuum.io/miniconda/Miniconda3-$CONDA_VERSION-Linux-x86_64.sh \
-    && echo "${CONDA_MD5}  Miniconda3-$CONDA_VERSION-Linux-x86_64.sh" > miniconda.md5 \
+    && wget --quiet https://repo.continuum.io/miniconda/${CONDA_FILENAME} \
+    && echo "${CONDA_FILENAME_MD5}  ${CONDA_FILENAME}" > miniconda.md5 \
     && if [ $(md5sum -c miniconda.md5 | awk '{print $2}') != "OK" ] ; then exit 1; fi \
-    && mv Miniconda3-$CONDA_VERSION-Linux-x86_64.sh miniconda.sh \
+    && mv ${CONDA_FILENAME} miniconda.sh \
     && sh ./miniconda.sh -b -p /opt/conda \
     && rm miniconda.sh miniconda.md5 \
     && ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh \

--- a/alpine-conda/Dockerfile
+++ b/alpine-conda/Dockerfile
@@ -19,6 +19,7 @@ ENV PYTHONDONTWRITEBYTECODE=true
 # - Remove all conda managed *.pyc files
 # - Cleanup conda files
 # - Uninstall miniconda install dependencies
+# Allow chown into opt so that the user can write/ create additional installations
 RUN apk add --no-cache wget bzip2 \
     && addgroup -S anaconda \
     && adduser -D -u 10151 anaconda -G anaconda \
@@ -37,7 +38,7 @@ RUN apk add --no-cache wget bzip2 \
     && find /opt/conda/ -follow -type f -name '*.a' -delete \
     && find /opt/conda/ -follow -type f -name '*.pyc' -delete \
     && /opt/conda/bin/conda clean -afy \
-    && chown -R anaconda:anaconda /opt/conda \
+    && chown -R anaconda:anaconda /opt/ \
     && apk del wget bzip2
 
 USER anaconda:anaconda

--- a/alpine-conda/Dockerfile
+++ b/alpine-conda/Dockerfile
@@ -21,7 +21,6 @@ ENV PYTHONDONTWRITEBYTECODE=true
 # - Remove all conda managed *.pyc files
 # - Cleanup conda files
 # - Uninstall miniconda install dependencies
-# Allow chown into opt so that the user can write/ create additional installations
 
 RUN apk add --no-cache wget bzip2 \
     && addgroup -S anaconda \
@@ -43,6 +42,9 @@ RUN apk add --no-cache wget bzip2 \
     && /opt/conda/bin/conda clean -afy \
     && chown -R anaconda:anaconda /opt/conda \
     && apk del wget bzip2
+
+USER anaconda:anaconda
+WORKDIR /home/anaconda/
 
 COPY start.sh /usr/local/bin/
 

--- a/alpine-conda/Dockerfile
+++ b/alpine-conda/Dockerfile
@@ -23,7 +23,7 @@ ENV PYTHONDONTWRITEBYTECODE=true
 # - Uninstall miniconda install dependencies
 # Allow chown into opt so that the user can write/ create additional installations
 
-RUN apk add --no-cache wget bzip2 bash findutils \
+RUN apk add --no-cache wget bzip2 \
     && addgroup -S anaconda \
     && adduser -D -u 10151 anaconda -G anaconda \
     && wget --quiet https://repo.continuum.io/miniconda/${CONDA_FILENAME} \
@@ -41,7 +41,7 @@ RUN apk add --no-cache wget bzip2 bash findutils \
     && find /opt/conda/ -follow -type f -name '*.a' -delete \
     && find /opt/conda/ -follow -type f -name '*.pyc' -delete \
     && /opt/conda/bin/conda clean -afy \
-    && chown -R anaconda:anaconda /opt/ \
+    && chown -R anaconda:anaconda /opt/conda \
     && apk del wget bzip2
 
 COPY start.sh /usr/local/bin/


### PR DESCRIPTION
Upgrade to 4.7.12 (.1) - patch version for download but install on 4.7.12.

See https://github.com/conda/conda/issues/9345 for more info.